### PR TITLE
getActiveOrgs >> getByTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ returns an object:
 }
 ```
 
-### request.server.pg.organisations.getByTag(active, filter, cb)
+### request.server.pg.organisations.orgsGetByTag(active, filter, cb)
 where
 `active` is a Boolean value; Setting this to `false` will return _all_ (active
   and inactive) organisations. `true` will return _active_ orgs only.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,24 @@ returns an object:
   ]
 }
 ```
+
+### request.server.pg.organisations.getByTag(active, filter, cb)
+where
+`active` is a Boolean value; Setting this to `false` will return _all_ (active
+  and inactive) organisations. `true` will return _active_ orgs only.
+`filter` corresponds to a tag ID. Organisations are filtered by this, and the
+  query will return only return organisations associated with the tag ID
+  specified.
+
+returns an object of the following format:
+```js
+{
+  filter_tag: 69,
+  orgs: {
+    id: 1,
+    name: 'Apple AAAA',
+    logo_url: 'google.com/?search=appleaaaa',
+    active: true
+  }
+}
+```

--- a/example/server.js
+++ b/example/server.js
@@ -119,9 +119,9 @@ function init (config, callback) {
           },
           {
             method: 'GET',
-            path: '/getActiveOrgs',
+            path: '/orgsGetByTag',
             handler: function (request, reply) {
-              request.server.methods.pg.organisations.getActiveOrgs(function (error, response) { // eslint-disable-line
+              request.server.methods.pg.organisations.orgsGetByTag(request.query.active, request.query.tags, function (error, response) { // eslint-disable-line
                 reply(response);
               });
             }

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -3,5 +3,6 @@
 /* eslint-disable */
 
 module.exports = {
-  orgsGetDetails: require('./orgsGetDetails.js')
+  orgsGetDetails: require('./orgsGetDetails.js'),
+  orgsGetByTag: require('./orgsGetByTag.js')
 };

--- a/lib/formatters/orgsGetByTag.js
+++ b/lib/formatters/orgsGetByTag.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function (data) {
+  var filter_tag = data[0].filter_tag || false;
+  var orgs = data.map(function (row) {
+    return {
+      id: row.id,
+      name: row.name,
+      logo_url: row.logo_url,
+      active: row.active
+    };
+  });
+
+  return { filter_tag: filter_tag, orgs: orgs };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,11 @@ function register (server, options, next) {
   var orgsGetByTag = function (active, filter, cb) {
     return query(queries.orgsGetByTag(active, filter), pool,
       function (err, rows) {
-        var res = !err ? formatters.orgsGetByTag(rows) : err;
+        if (err) {
+          return cb(err, null);
+        }
 
-        return cb(err, res);
+        return cb(err, formatters.orgsGetByTag(rows));
       });
   };
   var orgsGetDetails = function (id, cb) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,8 @@ function register (server, options, next) {
   var addOrgName = function (orgName, cb) {
     return query(queries.addOrgName(orgName), pool, cb);
   };
-  var getActiveOrgs = function (cb) {
-    return query(queries.getActiveOrgs, pool, cb);
+  var orgsGetByTag = function (active, filter, cb) {
+    return query(queries.orgsGetByTag(active, filter), pool, cb);
   };
   var orgsGetDetails = function (id, cb) {
     return query(queries.orgsGetDetails(id), pool, function (err, rows) {
@@ -41,8 +41,9 @@ function register (server, options, next) {
     server.method('pg.people.getAllPeople', getAllPeople);
     server.method('pg.people.getBy', peopleGetBy);
     server.method('pg.organisations.addOrgName', addOrgName);
-    server.method('pg.organisations.getActiveOrgs', getActiveOrgs);
-    server.method('pg.organisations.getById', getActiveOrgs);
+    server.method('pg.organisations.orgsGetByTag', orgsGetByTag);
+    // COMMENTED BELOW LINE OUT AS DOES NOT YET EXIST
+    // server.method('pg.organisations.getById', getActiveOrgs);
     server.method('pg.organisations.getDetails', orgsGetDetails);
 
     return next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,12 @@ function register (server, options, next) {
     return query(queries.addOrgName(orgName), pool, cb);
   };
   var orgsGetByTag = function (active, filter, cb) {
-    return query(queries.orgsGetByTag(active, filter), pool, cb);
+    return query(queries.orgsGetByTag(active, filter), pool,
+      function (err, rows) {
+        var res = !err ? formatters.orgsGetByTag(rows) : err;
+
+        return cb(err, res);
+      });
   };
   var orgsGetDetails = function (id, cb) {
     return query(queries.orgsGetDetails(id), pool, function (err, rows) {

--- a/lib/queries/getActiveOrgs.js
+++ b/lib/queries/getActiveOrgs.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = 'SELECT '
-  + 'id, '
-  + 'name, '
-  + 'logo_url, '
-  + 'mission_statement, '
-  + 'active '
-  + 'FROM organisations where active = true ORDER BY name;';

--- a/lib/queries/index.js
+++ b/lib/queries/index.js
@@ -3,13 +3,13 @@
 var getAllPeople = require('./getAllPeople.js');
 var peopleGetBy = require('./peopleGetBy.js');
 var addOrgName = require('./addOrgName.js');
-var getActiveOrgs = require('./getActiveOrgs.js');
+var orgsGetByTag = require('./orgsGetByTag.js');
 var orgsGetDetails = require('./orgs/getDetails.js');
 
 module.exports = {
   getAllPeople: getAllPeople,
   peopleGetBy: peopleGetBy,
   addOrgName: addOrgName,
-  getActiveOrgs: getActiveOrgs,
+  orgsGetByTag: orgsGetByTag,
   orgsGetDetails: orgsGetDetails
 };

--- a/lib/queries/orgsGetByTag.js
+++ b/lib/queries/orgsGetByTag.js
@@ -11,13 +11,17 @@ module.exports = function (active, tagId) {
   ];
 
   if (!active && !tagId) {
-    return query.join(' ');
+    return query.concat([
+      'ORDER BY organisations.name ASC',
+      ';'
+    ]).join(' ');
   } else if (active && !tagId) {
     return query.concat([
       'WHERE organisations.active = ' + active,
+      'ORDER BY organisations.name ASC',
       ';']).join(' ');
   } else if (!active && tagId) {
-    query.splice(1, 0, 'tags.name AS tags_name,');
+    query.splice(1, 0, 'tags.name AS filter_tag,');
 
     return query.concat([
       'JOIN tags_organisations',
@@ -25,10 +29,11 @@ module.exports = function (active, tagId) {
       'JOIN tags',
       'ON tags_organisations.tags_id = tags.id',
       'WHERE tags.id = ' + tagId,
+      'ORDER BY organisations.name ASC',
       ';']).join(' ');
   }
   // If active && filter: eslint-disable-line
-  query.splice(1, 0, 'tags.name AS tags_name,');
+  query.splice(1, 0, 'tags.name AS filter_tag,');
 
   return query.concat([
     'JOIN tags_organisations',
@@ -37,5 +42,6 @@ module.exports = function (active, tagId) {
     'ON tags_organisations.tags_id = tags.id',
     'WHERE tags.id = ' + tagId,
     'AND organisations.active = ' + active,
+    'ORDER BY organisations.name ASC',
     ';']).join(' ');
 };

--- a/lib/queries/orgsGetByTag.js
+++ b/lib/queries/orgsGetByTag.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports = function (active, tagId) {
+  var query = [
+    'SELECT',
+    'organisations.id AS id,',
+    'organisations.name AS name,',
+    'organisations.logo_url AS logo_url,',
+    'organisations.active AS active',
+    'FROM organisations'
+  ];
+
+  if (!active && !tagId) {
+    return query.join(' ');
+  } else if (active && !tagId) {
+    return query.concat([
+      'WHERE organisations.active = ' + active,
+      ';']).join(' ');
+  } else if (!active && tagId) {
+    query.splice(1, 0, 'tags.name AS tags_name,');
+
+    return query.concat([
+      'JOIN tags_organisations',
+      'ON tags_organisations.organisations_id = organisations.id',
+      'JOIN tags',
+      'ON tags_organisations.tags_id = tags.id',
+      'WHERE tags.id = ' + tagId,
+      ';']).join(' ');
+  }
+
+  query.splice(1, 0, 'tags.name AS tags_name,');
+
+  return query.concat([
+    'JOIN tags_organisations',
+    'ON tags_organisations.organisations_id = organisations.id',
+    'JOIN tags',
+    'ON tags_organisations.tags_id = tags.id',
+    'WHERE tags.id = ' + tagId,
+    'AND organisations.active = ' + active,
+    ';']).join(' ');
+};

--- a/lib/queries/orgsGetByTag.js
+++ b/lib/queries/orgsGetByTag.js
@@ -27,7 +27,7 @@ module.exports = function (active, tagId) {
       'WHERE tags.id = ' + tagId,
       ';']).join(' ');
   }
-
+  // If active && filter: eslint-disable-line
   query.splice(1, 0, 'tags.name AS tags_name,');
 
   return query.concat([

--- a/tests/addOrgName.test.js
+++ b/tests/addOrgName.test.js
@@ -17,7 +17,7 @@ test('Add an organisation', function (t) {
     }, function (res) {
       server.inject({
         method: 'GET',
-        url: '/getActiveOrgs'
+        url: '/orgsGetByTag'
       }, function (resOrgs) {
         var orgMatch = resOrgs.result.filter(function (org) {
           return org.name === 'aNewOrg';

--- a/tests/addOrgName.test.js
+++ b/tests/addOrgName.test.js
@@ -19,7 +19,7 @@ test('Add an organisation', function (t) {
         method: 'GET',
         url: '/orgsGetByTag'
       }, function (resOrgs) {
-        var orgMatch = resOrgs.result.filter(function (org) {
+        var orgMatch = resOrgs.result.orgs.filter(function (org) {
           return org.name === 'aNewOrg';
         })
         t.equal(orgMatch.length, 1, 'The org is saved');

--- a/tests/orgsGetByTag.test.js
+++ b/tests/orgsGetByTag.test.js
@@ -31,3 +31,38 @@ test('Get all the active organisations', function (t) {
     });
   });
 });
+
+test('Get all the active organisations, associated with a specific tag', function (t) {
+  var tagId = 69;
+  init(config, function (err, server, pool) {
+    if (err) {
+      console.log('error initialise server', err);
+      return t.fail();
+    }
+
+    server.inject({
+      method: 'GET',
+      url: '/orgsGetByTag?active=true&tags=' + tagId
+    }, function (res) {
+      var json = JSON.parse(res.payload)
+      var expected = [ {
+        tags_name: 'Design for disassembly',
+        id: 4,
+        name: 'EMF',
+        logo_url: 'https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8',
+        active: true
+      }, {
+        tags_name: 'Design for disassembly',
+        id: 5,
+        name: 'Co-op Group',
+        logo_url: 'https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8',
+        active: true }
+      ];
+      t.ok(res.result.length = 2, 'There are 2 active orgs associated to tagId ' + tagId);
+      t.deepEqual(expected, res.result, 'The org retreived is correct');
+      t.end();
+      pool.end()
+      server.stop()
+    });
+  });
+});

--- a/tests/orgsGetByTag.test.js
+++ b/tests/orgsGetByTag.test.js
@@ -13,14 +13,13 @@ test('Get all the active organisations', function (t) {
 
     server.inject({
       method: 'GET',
-      url: '/getActiveOrgs'
+      url: '/orgsGetByTag?active=true'
     }, function (res) {
       var json = JSON.parse(res.payload)
       var expected = {
         id: 1,
         name: "Apple AAAA",
         logo_url: "https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8",
-        mission_statement: "Change the economy",
         active: true
       };
       var appleOrg = res.result.filter(function (org) { return org.name === 'Apple AAAA'; })[0];

--- a/tests/orgsGetByTag.test.js
+++ b/tests/orgsGetByTag.test.js
@@ -15,15 +15,14 @@ test('Get all the active organisations', function (t) {
       method: 'GET',
       url: '/orgsGetByTag?active=true'
     }, function (res) {
-      var json = JSON.parse(res.payload)
       var expected = {
         id: 1,
         name: "Apple AAAA",
         logo_url: "https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8",
         active: true
       };
-      var appleOrg = res.result.filter(function (org) { return org.name === 'Apple AAAA'; })[0];
-      t.ok(res.result.length > 3, 'There are more than 3 active orgs');
+      var appleOrg = res.result.orgs.filter(function (org) { return org.name === 'Apple AAAA'; })[0];
+      t.ok(res.result.orgs.length > 3, 'There are more than 3 active orgs');
       t.deepEqual(appleOrg, expected, 'The org retreived is correct');
       t.end();
       pool.end()
@@ -44,22 +43,21 @@ test('Get all the active organisations, associated with a specific tag', functio
       method: 'GET',
       url: '/orgsGetByTag?active=true&tags=' + tagId
     }, function (res) {
-      var json = JSON.parse(res.payload)
+      var filter = 'Design for disassembly'
       var expected = [ {
-        tags_name: 'Design for disassembly',
+        id: 5,
+        name: 'Co-op Group',
+        logo_url: 'https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8',
+        active: true
+      }, {
         id: 4,
         name: 'EMF',
         logo_url: 'https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8',
         active: true
-      }, {
-        tags_name: 'Design for disassembly',
-        id: 5,
-        name: 'Co-op Group',
-        logo_url: 'https://www.google.co.uk/imgres?iitter.com%2Fcirculareconomy&docid=LnflHf1c&uact=8',
-        active: true }
-      ];
-      t.ok(res.result.length = 2, 'There are 2 active orgs associated to tagId ' + tagId);
-      t.deepEqual(expected, res.result, 'The org retreived is correct');
+      }];
+      t.ok(res.result.orgs.length = 2, 'There are 2 active orgs associated to tagId ' + tagId);
+      t.deepEqual(expected, res.result.orgs, 'The org retreived is correct');
+      t.equal(filter, res.result.filter_tag, 'The query response has been correctly formatted');
       t.end();
       pool.end()
       server.stop()


### PR DESCRIPTION
Closes #25 
Closes #26 
Closes #29 

upgrades the getActiveOrgs functionality by passing it `active` and `filter/tagId1 parameters, which help to return the correct query string, thus allowing us to query the db for the correct list of organisations.